### PR TITLE
Fixes a bug where the print button would ignore user input

### DIFF
--- a/src/main/java/org/daniel/microflow/controller/Controller.java
+++ b/src/main/java/org/daniel/microflow/controller/Controller.java
@@ -468,8 +468,9 @@ public class Controller extends MouseAdapter implements ActionListener {
         });
 
         try {
-            pj.printDialog();
-            pj.print();
+            if (pj.printDialog()) {
+                pj.print();
+            }
         } catch (PrinterException ex) {
             ex.printStackTrace();
         }


### PR DESCRIPTION
When you press the print button, the print dialog will open, giving you two options: either to print or not to print. 
Before fixing this bug, even if the user pressed "Cancel", the print would begin. 
Now, the print will only begin if the user hits "OK", and is dismissed otherwise.

Signed-off-by: Iscle <albertiscle9@gmail.com>